### PR TITLE
make the template work as the README states

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Next we modify the secret yaml and replace the existing values:
 ```
  # replace username, password and URL in file cdk-f5-big-ip.yaml:
 sed -i 's/YWRtaW4=/<BASE64-USERNAME>/g' cdk-f5-big-ip.yaml
-sed -i 's/somepassword/<BASE64-PASSWORD>/g' cdk-f5-big-ip.yaml
+sed -i 's/base64password/<BASE64-PASSWORD>/g' cdk-f5-big-ip.yaml
 sed -i 's/aHR0cHM6Ly8xMC4xOTAuMjEuMTQ4Cg==/<BASE64-F5-URL>/g' cdk-f5-big-ip.yaml
 ```
 

--- a/cdk-f5-big-ip.yaml
+++ b/cdk-f5-big-ip.yaml
@@ -5,9 +5,9 @@ metadata:
   name: bigip-credentials
 type: Opaque
 data:
-  url: NTIuMzAuMjUuMjEz
-  username: YWRtaW4=
-  password: YWRtaW4=
+  url: <BASE64-F5-URL>
+  username: <BASE64-USERNAME>
+  password: <BASE64-PASSWORD>
 ---
   apiVersion: v1
   kind: ServiceAccount


### PR DESCRIPTION
The readme talks about using sed to replace variable sin the template, but those variables don't actually exist, so I've put them in